### PR TITLE
mDNS republish

### DIFF
--- a/munkey/configure.ts
+++ b/munkey/configure.ts
@@ -52,8 +52,16 @@ function configureRoutes(services: ServiceContainer, options?: ServerOptions): P
             vaults: await services.vault.getActiveVaultList(),
             activePeerList: services.activity.getDeviceList(),
         };
-
         response.json(identityResponse).end();
+    });
+
+    app.post("/link", async function(request, response) {
+        if (!request.body?.hasOwnProperty("uniqueId"))
+            return response.status(400);
+
+        let { uniqueId } = request.body;
+        await services.activity.restorePeer(uniqueId);
+        response.end();
     });
 
     if (pouch) {

--- a/munkey/munkey.ts
+++ b/munkey/munkey.ts
@@ -189,13 +189,24 @@ generateNewIdentity(commandLineArgs.root_dir)
                 }
                 
                 return new Promise(function(resolve, reject) {
-                    grpcServer.tryShutdown(err => {
-                        if (err) reject(err);
-                        resolve(services);
-                    });
+                    function shutdown() {
+                        grpcServer.tryShutdown(err => {
+                            if (err)
+                                reject(err);
+                            resolve(services);
+                        });
+                    }
+                    process.on("SIGINT", shutdown);
+                    process.on("SIGKILL", shutdown);
+                    process.on("SIGTERM", shutdown);
                 });
             });
     })
+    .then(() => {
+        console.info("Goodbye!");
+        process.exit(0);
+    })
     .catch(err => {
         console.error(err);
+        process.exit(1);
     });

--- a/munkey/server/CommandServer.ts
+++ b/munkey/server/CommandServer.ts
@@ -52,9 +52,15 @@ abstract class CommandServer {
                 return failItem({ message: vaultResult.message });
             }
 
-            return await vaultResult.data.initialize(initialData)
-                ? successItem(vaultId, { message: "Vault created successfully" })
-                : failItem({ message: "Failed to initialize vault" });
+            let x = await vaultResult.data.initialize(initialData);
+            if (!x)
+                return failItem({ message: "Failed to initialize vault" });
+            return await this.services.activity.republish(this.services.identity.getId())
+                .then(() => successItem<string, VaultStatus>(vaultId, { message: "Vault created successfully" }))
+                .catch(() => failItem<string, VaultStatus>({ message: "Failed to republish vault" }));
+            // return await vaultResult.data.initialize(initialData)
+            //     ? successItem(vaultId, { message: "Vault created successfully" })
+            //     : failItem({ message: "Failed to initialize vault" });
         }
         catch (err) {
             return failItem<string, VaultStatus>({

--- a/munkey/server/ShellCommandServer.ts
+++ b/munkey/server/ShellCommandServer.ts
@@ -90,6 +90,10 @@ class ShellCommandServer extends CommandServer {
             console.error("Missing name for vault login");
             return Promise.resolve(null);
         }
+        if (!this.services.vault.getVaultByName(vaultName)) {
+            console.error(`Vault not found: ${vaultName}`);
+            return Promise.resolve(null);
+        }
 
         return Promise.resolve(stream => this.promptPasswordCreation(stream)
             .then(async cipher => {
@@ -199,6 +203,10 @@ class ShellCommandServer extends CommandServer {
         }
 
         const vault = this.services.vault.getVaultByName(this.activeVault?.name);
+        if (!vault) {
+            console.error("Current vault could not be resolved");
+            return Promise.resolve(null);
+        }
 
         return vault.getContent()
             .then(rawContent => {
@@ -286,6 +294,7 @@ class ShellCommandServer extends CommandServer {
                 console.error(`To try logging in again, use the command: vault login ${vaultName}`);
             }
             else {
+                this.activeVault = { name: vaultName, cipher };
                 console.info(`Vault link successful: ${vaultName}@${hostname}:${portNum}`);
             }
         });

--- a/munkey/services/activity.ts
+++ b/munkey/services/activity.ts
@@ -159,6 +159,8 @@ export default class ActivityService extends Service {
         this.logger.info("Attempting to publish peer device %s:%d", device.hostname, device.portNum);
         return this.sendLinkRequest(device.hostname, device.portNum)
             .then(async decl => {
+                if (!decl)
+                    return null;
                 this.logger.info("Published peer device %s:%d", device.hostname, device.portNum);
                 this.activePeerList.set(`${device.hostname}:${device.portNum}`, decl);
                 let { activePeerList = [] } = decl ?? {};

--- a/munkey/services/identity.ts
+++ b/munkey/services/identity.ts
@@ -40,9 +40,9 @@ export default class IdentityService extends Service {
                                  certPath: string = path.join(rootDir, "tls.crt")): Promise<TlsKeyPair>
     {
         return Promise.all([
-            IdentityService.loadKey(keyPath),
-            IdentityService.loadKey(certPath)
-        ])
+                IdentityService.loadKey(keyPath),
+                IdentityService.loadKey(certPath)
+            ])
             .then(([ key, cert ]) => ({ key, cert }));
     }
 

--- a/munkey/services/vault/VaultDatabase.ts
+++ b/munkey/services/vault/VaultDatabase.ts
@@ -8,6 +8,10 @@ export default class VaultDatabase {
     private readonly logger?: winston.Logger;
 
     constructor(vault: VaultDB, vaultId: string, logger?: winston.Logger) {
+        if (!vault)
+            throw new Error("new VaultDatabase(): argument `vault` is null");
+        if (!vaultId)
+            throw new Error("new VaultDatabase(): argument `vaultId` is null");
         this.vault = vault;
         this.vaultId = vaultId;
         this.logger = logger;

--- a/munkey/services/vault/VaultService.ts
+++ b/munkey/services/vault/VaultService.ts
@@ -28,9 +28,9 @@ export default class VaultService extends Service {
         return this.vaultIdMap.has(vaultName);
     }
 
-    private loadVaultDb(vaultName: string): VaultDatabase {
+    private loadVaultDb(vaultName: string, vaultId: string): VaultDatabase {
         const vaultDb = this.vaultContext.load(vaultName);
-        return new VaultDatabase(vaultDb, this.vaultIdMap.get(vaultName), this.logger);
+        return new VaultDatabase(vaultDb, vaultId, this.logger);
     }
 
     private setVaultEntry(vaultName: string, vaultId: string, vault: VaultDatabase): VaultDatabase {
@@ -69,6 +69,7 @@ export default class VaultService extends Service {
 
         const vaultDb = this.vaultContext.create(vaultName); // fails if the database already exists on-disk
         const vault = new VaultDatabase(vaultDb, vaultId, this.logger);
+        this.adminService?.recordVaultCreation(vaultName, vaultId);
         return successItem(this.setVaultEntry(vaultName, vaultId, vault));
     }
 
@@ -136,7 +137,7 @@ export default class VaultService extends Service {
         }
 
         try {
-            const vault = this.loadVaultDb(vaultName);
+            const vault = this.loadVaultDb(vaultName, vaultId);
             this.setVaultEntry(vaultName, vaultId, vault);
             return successItem<VaultDatabase, VaultStatus>(vault);
         }


### PR DESCRIPTION
When a new Vault is created locally, the service automatically notifies any known peers that the associated device has changed.

This fixes a bug where a service restart is required for peer discovery to find new vaults.