### PR TITLE
SSL Generation

### DIFF
--- a/munkey/configure.ts
+++ b/munkey/configure.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import fs from "fs";
 import express from "express";
 import PouchDB from "pouchdb";
 import usePouchDB from "express-pouchdb";
@@ -15,6 +16,11 @@ export interface ServerOptions {
     pouch?: PouchConstructor<DatabaseDocument>;
     discoveryPortNum?: number;
     rootPath?: string;
+}
+
+export function resolveSystemFolder() {
+    let rootEnv = process.platform === "win32" ? "APPDATA" : "HOME";
+    return path.join(process.env[rootEnv], "MunkeyService");
 }
 
 /**
@@ -38,6 +44,10 @@ function configureRoutes(services: ServiceContainer, options?: ServerOptions): P
         pouch = null,
         discoveryPortNum = null,
     } = options ?? {};
+    if (!fs.existsSync(rootPath)) {
+        fs.mkdirSync(rootPath, 0o600);
+    }
+
     const app = services.web.getApplication();
     const pouchOptions = !rootPath ? {}
         : { logPath: path.resolve(rootPath) + path.sep + "log.txt" };

--- a/munkey/munkey.ts
+++ b/munkey/munkey.ts
@@ -34,6 +34,7 @@ import {
     configurePlugins,
     configureLogging,
     DatabasePluginAttachment,
+    resolveSystemFolder,
 } from "./configure";
 import { ShellCommandServer } from "./server";
 import {
@@ -82,8 +83,7 @@ const parseCommandLineArgs = function(argv: string[] = process.argv.slice(2)): C
     parser.add_argument("-r", "--root-dir", {
         help: "Root directory where all database and configuration files will be stored to and loaded from",
         action: PathResolver,
-        // TODO: on release, change this to something else (temp/home dir maybe?)
-        default: path.resolve("localhost"),
+        default: resolveSystemFolder(),
     });
     parser.add_argument("-p", "--port", {
         help: "Initial port number for the web server to listen on (can be reconfigured at runtime)",

--- a/munkey/package-lock.json
+++ b/munkey/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^4.17.1",
         "express-pouchdb": "^4.2.0",
         "memdown": "^6.1.1",
+        "node-forge": "^1.3.1",
         "pouchdb": "^7.2.2",
         "winston": "^3.3.3"
       },
@@ -28,6 +29,7 @@
         "@types/memdown": "^3.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^15.14.9",
+        "@types/node-forge": "^1.0.1",
         "@types/pouchdb": "^6.4.0",
         "@types/pouchdb-core": "^7.0.10",
         "@types/sinon": "^10.0.6",
@@ -369,6 +371,15 @@
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.0.1.tgz",
+      "integrity": "sha512-96ELNKv9tQJ19afdBUiM5iDw7OYEc53iUc51gAPR2aGaqRsO1DBROjqgZRjZa1tkPj7TnEOR0EnyAX6iryGkzA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/pouchdb": {
       "version": "6.4.0",
@@ -3166,6 +3177,14 @@
         "node": "4.x || >=6.0.0"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
@@ -5112,6 +5131,15 @@
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
       "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+    },
+    "@types/node-forge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.0.1.tgz",
+      "integrity": "sha512-96ELNKv9tQJ19afdBUiM5iDw7OYEc53iUc51gAPR2aGaqRsO1DBROjqgZRjZa1tkPj7TnEOR0EnyAX6iryGkzA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/pouchdb": {
       "version": "6.4.0",
@@ -7298,6 +7326,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-gyp-build": {
       "version": "4.1.1",

--- a/munkey/package.json
+++ b/munkey/package.json
@@ -26,6 +26,7 @@
     "@types/memdown": "^3.0.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^15.14.9",
+    "@types/node-forge": "^1.0.1",
     "@types/pouchdb": "^6.4.0",
     "@types/pouchdb-core": "^7.0.10",
     "@types/sinon": "^10.0.6",
@@ -47,6 +48,7 @@
     "express": "^4.17.1",
     "express-pouchdb": "^4.2.0",
     "memdown": "^6.1.1",
+    "node-forge": "^1.3.1",
     "pouchdb": "^7.2.2",
     "winston": "^3.3.3"
   }

--- a/munkey/services/identity.ts
+++ b/munkey/services/identity.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import { readFile } from "fs";
+import { pki } from "node-forge";
+import { readFile, mkdir } from "fs";
 import { randomUUID } from "crypto";
 
 import Service from "./baseService";
@@ -35,26 +36,27 @@ export default class IdentityService extends Service {
         return this.uniqueId;
     }
 
-    public static loadTlsKeyPair(rootDir: string,
-                                 keyPath: string = path.join(rootDir, "tls.key"),
-                                 certPath: string = path.join(rootDir, "tls.crt")): Promise<TlsKeyPair>
-    {
-        return Promise.all([
-            IdentityService.loadKey(keyPath),
-            IdentityService.loadKey(certPath)
-        ])
-            .then(([ key, cert ]) => ({ key, cert }));
-    }
+    private static rsaOptions: pki.rsa.GenerateKeyPairOptions = {
+        bits: 2048,
+    };
 
-    private static loadKey(keyPath: string): Promise<Buffer> {
-        return new Promise<Buffer>(function(resolve, reject) {
-            readFile(keyPath, (err, data: Buffer) => {
+    public static async loadTlsKeyPair(rootDir: string): Promise<TlsKeyPair> {
+        let { publicKey, privateKey } = await new Promise<pki.rsa.KeyPair>(function(resolve, reject) {
+            pki.rsa.generateKeyPair(IdentityService.rsaOptions, (err, keyPair) => {
                 if (err) reject(err);
-                else {
-                    resolve(data);
-                }
+                resolve(keyPair);
             });
         });
+
+        let cert = pki.createCertificate();
+        cert.publicKey = publicKey;
+        cert.sign(privateKey);
+        cert.validity.notAfter = new Date();
+        cert.validity.notAfter.setFullYear(2100); // temporary, until per-device identity model is implemented
+        return {
+            key: Buffer.from(pki.privateKeyToPem(privateKey)),
+            cert: Buffer.from(pki.certificateToPem(cert))
+        };
     }
 
     public getTlsKeyPair(): TlsKeyPair {
@@ -72,7 +74,7 @@ export default class IdentityService extends Service {
 async function generateNewIdentity(rootDir: string): Promise<{ uniqueId: string } & TlsKeyPair> {
     const keyPair = await IdentityService.loadTlsKeyPair(rootDir)
         .catch(err => {
-            console.error("Could not load TLS certificate:", err);
+            console.error("Could not load TLS certificate:", err.message);
             return { key: undefined, cert: undefined };
         });
 


### PR DESCRIPTION
Uses the `node-forge` package to generate a default, self-signed TLS certificate at startup. This will be an acceptable implementation until a per-device identity model is implemented (currently, there is only a "global" identity model).

# Changes
- Generates HTTPS key/cert at startup, instead of reading from disk
- Creates `MunkeyService` folder in `%AppData%`